### PR TITLE
Restrict deploy ci to main and tag v.*

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -2,8 +2,6 @@ name: Docker Image CI
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -14,6 +12,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
+      - name: Exit if not on main branch
+        if: endsWith(github.ref, 'main') == false
+        run: exit -1
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -50,6 +52,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
+      - name: Exit if not on main branch
+        if: endsWith(github.ref, 'main') == false
+        run: exit -1
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
The default behavior for github when requesting to run on main and tags is to run if either one of them run. 

This PR implements an additional check to exit if a v* tag is used on another branch than main.